### PR TITLE
refactor: Not needed dependencies removed/moved to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "yarn clean && tsc",
     "format": "prettier --write {src,test}/**/*.ts",
     "lint": "tslint --project . src/**/*.ts",
-    "prepare": "install-self-peers -- --ignore-scripts",
+    "prepare": "install-self-peers --npm -- --ignore-scripts --no-save",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "semantic-release": "semantic-release"
@@ -41,13 +41,12 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
-    "aws-lambda": "^0.1.2",
     "class-validator-jsonschema": "^1.3.0",
     "http-status-codes": "^1.4.0",
-    "reflect-metadata": "^0.1.13",
     "winston": "^3.2.1"
   },
   "peerDependencies": {
+    "reflect-metadata": "^0.1.13",
     "class-transformer": "^0.2.3",
     "class-validator": "^0.9.1"
   }


### PR DESCRIPTION
* I think `aws-lambda` added to dependencies by mistake. Removed it
* `reflect-metadata` mentioned in Readme file to be installed separately. That means it should be a peerDependency. Moved it.
* `install-self-peers` expecting `yarn` to be installed. `yarn` is not a dependency. I preferred to run it via npm.

ps: `build` command is also needs yarn, now. I couldn't find npm equivalent of `yarn cache`. But I thinks it's also wise to build project with npm.